### PR TITLE
PWM Outputs PRU

### DIFF
--- a/DeviceTreeOverlay/am335x-boneblack-bbbmini.dts
+++ b/DeviceTreeOverlay/am335x-boneblack-bbbmini.dts
@@ -184,11 +184,11 @@
 	};
 };
 
-//&pruss {
-//	pinctrl-names = "default";
-//	pinctrl-0 = <&pru_pins>;
-//	status = "okay";
-//};
+&pruss {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pru_pins>;
+	status = "okay";
+};
 
 &uart4 {
 	pinctrl-names = "default";


### PR DESCRIPTION
Enable PWM/GPIO Outputs:
They were disabled initially, commented the pru lines.